### PR TITLE
Feat apply tdp versioning for unversioned livy 0.8.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-api</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-assembly</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-common</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-http</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-core-parent</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/core/scala-2.11/pom.xml
+++ b/core/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.11</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.12/pom.xml
+++ b/core/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.12</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
   </parent>
 
   <artifactId>livy-coverage-report</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/docs/_data/project.yml
+++ b/docs/_data/project.yml
@@ -16,6 +16,6 @@
 # Apache Project configurations
 #
 name: Apache Livy
-version: 0.8.0-incubating-SNAPSHOT
+version: 0.8.0-incubating-1.0
 
 podling: true

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-examples</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
   </parent>
 
   <artifactId>livy-integration-test</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-main</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>pom</packaging>
   <name>Livy Project Parent POM</name>
   <description>Livy Project</description>

--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-python-api</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>pom</packaging>
 
   <build>

--- a/python-api/setup.py
+++ b/python-api/setup.py
@@ -40,7 +40,7 @@ requirements = [
 
 setup(
     name='livy-python-api',
-    version="0.8.0-incubating-SNAPSHOT",
+    version="0.8.0-incubating-1.0",
     packages=["livy", "livy-tests"],
     package_dir={
         "": "src/main/python",

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
     <relativePath>../scala/pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
   </parent>
 
   <artifactId>livy-repl-parent</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/repl/scala-2.11/pom.xml
+++ b/repl/scala-2.11/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.11</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.12/pom.xml
+++ b/repl/scala-2.12/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.12</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/pom.xml
+++ b/scala-api/pom.xml
@@ -23,12 +23,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-scala-api-parent</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/scala-api/scala-2.11/pom.xml
+++ b/scala-api/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.11</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.12/pom.xml
+++ b/scala-api/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.12</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>multi-scala-project-root</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
   </parent>
 
   <artifactId>livy-server</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -1,6 +1,6 @@
 # TDP Livy Notes
 
-The version `0.8.0-incubating-TDP-0.1.0-SNAPSHOT` of Apache Livy is based on the `master` branch of the [Apache repository](https://github.com/apache/incubator-livy/tree/master).
+The version `0.8.0-incubating-1.0` of Apache Livy is based on the `master` branch of the [Apache repository](https://github.com/apache/incubator-livy/tree/master).
 
 The main purpose of this custom release is the support of Spark 3.2 that is used in TDP.
 
@@ -30,7 +30,7 @@ cd incubator-livy
 mvn clean package -DskipTests
 ```
 
-The command generates a `.zip` file of the release at `./assembly/target/apache-livy-0.8.0-incubating-TDP-0.1.0-SNAPSHOT-bin.zip`.
+The command generates a `.zip` file of the release at `./assembly/target/apache-livy-0.8.0-incubating-1.0-bin.zip`.
 
 ## Testing
 

--- a/tdp/test-notes.md
+++ b/tdp/test-notes.md
@@ -8,7 +8,7 @@
 
 ## Code changes
 
-1. Livy version: `0.8.0-incubating-SNAPSHOT` → `0.8.0-incubating-TDP-0.1.0-SNAPSHOT`
+1. Livy version: `0.8.0-incubating-1.0` → `0.8.0-incubating-1.0`
 2. Scala 2.12 version: `2.12.10` → `2.12.15`
 3. Plugin `net.alchim31.maven.scala-maven-plugin` version: `4.2.0` → `4.5.4`
 4. Add versions `3.1` and `3.2` in `_defaultSparkScalaVersion` map in [LivySparkUtils.scala](../server/src/main/scala/org/apache/livy/utils/LivySparkUtils.scala).

--- a/test-lib/pom.xml
+++ b/test-lib/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-test-lib</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-1.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/thriftserver/session/pom.xml
+++ b/thriftserver/session/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Apply TDP versioning for livy 0.8.0-incubating

This should rebuild the equivalent of 0.8.0-TDP-0.1.0-SNAPSHOT.

# Why version is not 0.7.0-1.0 ?

Considering TDP releasing policy, this version is based on 0.7.0, with additionals commits from master.

So the tdp version was based on 0.8.0-incubating-SNAPSHOT.

Problem is project livy has continued dev on 0.8.0, but also released specific 0.7.1 and 0.7.2 that are not integrated. So 0.7.0-1.0 would have been way more ahead than 0.7.1, which is quite confusing.

That is why I am proposing 0.8.0-1.0, even if 0.8.0 does not exist yet.
