### PR TITLE
5 Missing thriftsserver in release

### DIFF
--- a/tdp/README.md
+++ b/tdp/README.md
@@ -27,7 +27,9 @@ For more info, see [Start the container](https://github.com/TOSIT-IO/TDP/tree/ma
 
 ```bash
 cd incubator-livy
-mvn clean package -DskipTests
+# in order to create a create a new release adding thriftserver to an already published release
+# mvn clean package -DskipTests -P thriftserver '-Dassembly.name=apache-livy-${project.version}_${scala.binary.version}-bin-thrift'
+mvn clean package -DskipTests -P thriftserver
 ```
 
 The command generates a `.zip` file of the release at `./assembly/target/apache-livy-0.8.0-incubating-TDP-0.1.0-SNAPSHOT-bin.zip`.

--- a/tdp/bin/start-build-env.sh
+++ b/tdp/bin/start-build-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 IMAGE_NAME=tdp-builder-livy
 
@@ -7,22 +7,13 @@ docker build . -t "${IMAGE_NAME}"
 USER_NAME="${SUDO_USER:=$USER}"
 USER_ID=$(id -u "${USER_NAME}")
 GROUP_ID=$(id -g "${USER_NAME}")
-
-docker build -t "${IMAGE_NAME}-${USER_NAME}" - <<UserSpecificDocker
-FROM ${IMAGE_NAME}
-RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME}
-RUN useradd -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME}
-RUN echo "${USER_NAME} ALL=NOPASSWD: ALL" > "/etc/sudoers.d/tdp-builder-${USER_ID}"
-ENV HOME /home/${USER_NAME}
-
-UserSpecificDocker
-
 TDP_HOME="${TDP_HOME:=$(pwd)}"
 
 docker run --rm=true -t -i \
   -v "${TDP_HOME}:/tdp" \
   -w "/tdp" \
   -v "${HOME}/.m2:/home/${USER_NAME}/.m2${V_OPTS:-}" \
-  -u "${USER_NAME}" \
+  -e "BUILDER_UID=${USER_ID}" \
+  -e "BUILDER_GID=${GROUP_ID}" \
   --ulimit nofile=500000:500000 \
-  "${IMAGE_NAME}-${USER_NAME}"
+  "${IMAGE_NAME}"


### PR DESCRIPTION
Fixes (partially) #5 

I update start-build-env to a more modern solution, and also align it with the one found in TOSIT-IO/tdp

I added  build instructions to add thriftserver to the build.

Once validated, I suggest to run command with  a different assembly name, hence avoiding confusion in build. We would then upload the new -thrift.zip file to the releases in this repo